### PR TITLE
Fix middleware namespacing in favor of nordsoftware/lumen-core master.

### DIFF
--- a/src/Middleware/OAuth2Middleware.php
+++ b/src/Middleware/OAuth2Middleware.php
@@ -1,6 +1,6 @@
 <?php namespace Nord\Lumen\OAuth2\Middleware;
 
-use Nord\Lumen\Core\App\CreatesHttpResponses;
+use Nord\Lumen\Core\Traits\CreatesHttpResponses;
 use League\OAuth2\Server\Exception\OAuthException;
 use Nord\Lumen\OAuth2\Traits\AuthenticatesUsers;
 

--- a/src/OAuth2Middleware.php
+++ b/src/OAuth2Middleware.php
@@ -4,8 +4,8 @@ namespace Nord\Lumen\OAuth2;
 
 use Closure;
 use Illuminate\Http\Request;
-use Nord\Lumen\Core\App\AuthenticatesUsers;
-use Nord\Lumen\Core\App\CreatesHttpResponses;
+use Nord\Lumen\Core\Traits\AuthenticatesUsers;
+use Nord\Lumen\Core\Traits\CreatesHttpResponses;
 use League\OAuth2\Server\Exception\OAuthException;
 
 class OAuth2Middleware


### PR DESCRIPTION
Changes proposed in this pull request:
 * Fix namespacing from `Nord\Lumen\Core\App` => `Nord\Lumen\Core\Traits`

